### PR TITLE
Discovery speedups

### DIFF
--- a/InterfacesWindows.cpp
+++ b/InterfacesWindows.cpp
@@ -77,6 +77,9 @@ std::vector<interfaceInformation> interfaceList()
 
             interfaceInformation ifAddr;
             ifAddr.name = pCurrAddresses->AdapterName;
+            
+            if (pCurrAddresses->OperStatus != IfOperStatusUp)
+               continue;   // Ignore adapters not UP
 
             for (auto addr_i = pCurrAddresses->FirstUnicastAddress; addr_i != NULL; addr_i = addr_i->Next)
             {


### PR DESCRIPTION
Two commits to speed-up the SDR-discovery:
  * Ignore any link-local address (we cannot bind to it. And there is no-one there)
  * Ignore adapters that are not in *UP-state*.