### PR TITLE
Fix segfault caused by dereferencing NULL pointer in interfaceList()

### DIFF
--- a/InterfacesUnix.cpp
+++ b/InterfacesUnix.cpp
@@ -13,6 +13,9 @@ std::vector<interfaceInformation> interfaceList()
 	getifaddrs(&addrs);
 	for (iloop = addrs; iloop != NULL; iloop = iloop->ifa_next)
 	{
+		if (iloop->ifa_addr == NULL)
+			continue;
+
 		if (iloop->ifa_addr->sa_family != AF_INET) continue; //just IPv4
 
 		s4 = (struct sockaddr_in *)(iloop->ifa_addr);


### PR DESCRIPTION
The `getifaddrs` function can return structures where the `ifa_addr` field is `NULL` ([according to the man page](https://man7.org/linux/man-pages/man3/getifaddrs.3.html)). This adds a check for that before attempting anything else.

Fixes #6 for me.